### PR TITLE
Target Blank to #Wrapped2022

### DIFF
--- a/client/landing/components/Headbar.tsx
+++ b/client/landing/components/Headbar.tsx
@@ -7,6 +7,8 @@ const Headbar = () => {
         <a
           href="https://photos.google.com/share/AF1QipORRPNrrr85gqjyS5pE43TsBKHW8PxfwUJ3hKXAgdv0SxSTKeExuMFM9RiCbIPNLQ?key=UUtMem5BOS1LeF9kYU1MWmlYRk05eGhZVVJRYXRn"
           className="underline decoration-dashed"
+          target="_blank"
+          rel="noreferrer"
         >
           {" "}
           #2022Wrapped


### PR DESCRIPTION
### Description

Adds target blank to wrapped2022.
Link opens in new window.

closes #98