### PR TITLE
fix: form validation

### DIFF
--- a/client/dashboard/app/routes/start.tsx
+++ b/client/dashboard/app/routes/start.tsx
@@ -99,13 +99,13 @@ const validateUserDetails = async (formData: FormData) => {
     linkedin: Yup.string()
       .url("The URL you have entered doesn't seem right")
       .matches(
-        /^https?:\/\/(?:[a-z]+\.)?linkedin\.com\/in\/[a-zA-Z0-9_-]+$/,
+        /^(https?:\/\/(?:[a-z]+\.)?linkedin\.com\/in\/[a-zA-Z0-9_-]+)?$/,
         "The URL you have entered doesn't seem right"
       ),
     github: Yup.string()
       .url("The URL you have entered doesn't seem right")
       .matches(
-        /^https?:\/\/(?:[a-z]+\.)?github\.com\/[a-zA-Z0-9_-]+$/,
+        /^(https?:\/\/(?:[a-z]+\.)?github\.com\/[a-zA-Z0-9_-]+)?$/,
         "The URL you have entered doesn't seem right"
       ),
     resume: Yup.string(),


### PR DESCRIPTION
### This pr 

fixes #162 
- fixes the Linkedin, Github URL validation in `start.tsx` 

## submiting without links
![image](https://github.com/srm-kzilla/fury/assets/35625228/b05297fc-c856-40f5-a735-2b4c7f7b0c3d)

## submitting only linkedin
![image](https://github.com/srm-kzilla/fury/assets/35625228/8d232336-8434-4302-8acd-23097cd0184e)

## submitting wrong URL's with initials similar to correct url
![image](https://github.com/srm-kzilla/fury/assets/35625228/5842b6fa-75e6-418d-bf13-3152a707649f)

## submitting correct urls
![image](https://github.com/srm-kzilla/fury/assets/35625228/945cec0b-039b-415d-95d9-9fb53d820196)




