### PR TITLE
fix: linkedin regex

### DIFF
--- a/client/dashboard/app/routes/start.tsx
+++ b/client/dashboard/app/routes/start.tsx
@@ -113,7 +113,7 @@ const validateUserDetails = async (formData: FormData) => {
     linkedin: Yup.string()
       .url("The URL you have entered doesn't seem right")
       .matches(
-        /^(https?:\/\/(?:[a-z]+\.)?linkedin\.com\/in\/[a-zA-Z0-9_-]+)?$/,
+        /^(https?:\/\/(?:[a-z]+\.)?linkedin\.com\/in\/[a-zA-Z0-9_-]+\/?)?$/,
         "The URL you have entered doesn't seem right"
       ),
     github: Yup.string()

--- a/client/dashboard/app/routes/start.tsx
+++ b/client/dashboard/app/routes/start.tsx
@@ -119,7 +119,7 @@ const validateUserDetails = async (formData: FormData) => {
     github: Yup.string()
       .url("The URL you have entered doesn't seem right")
       .matches(
-        /^(https?:\/\/(?:[a-z]+\.)?github\.com\/[a-zA-Z0-9_-]+)?$/,
+        /^(https?:\/\/(?:[a-z]+\.)?github\.com\/[a-zA-Z0-9_-]+\/?)?$/,
         "The URL you have entered doesn't seem right"
       ),
     resume: Yup.string(),


### PR DESCRIPTION
This pr 

closes #370 
fixes the Regex issue with `https://www.linkedin.com/in/[slug]/`

TEST1
![image](https://github.com/srm-kzilla/fury/assets/35625228/72948421-fe30-4f2e-a7ff-6f360e482f4c)
TEST2
![image](https://github.com/srm-kzilla/fury/assets/35625228/43da2519-241a-4f4f-98d2-99577019210d)
TEST3
![image](https://github.com/srm-kzilla/fury/assets/35625228/1c845655-7065-4f22-8902-2d8a9e721a25)
TEST4 
![image](https://github.com/srm-kzilla/fury/assets/35625228/2aa6d77e-7454-4a0e-96c2-163e52fa180f)
TEST5
![image](https://github.com/srm-kzilla/fury/assets/35625228/02ec0470-6bcd-4516-ba4a-925753f993f7)
