### PR TITLE
Update Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -37,4 +37,4 @@ Please provide any relevant information about your setup. This is important in c
 ## Failure Logs
 
 Please include any relevant log snippets or files here.
-'+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,4 +44,4 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
-      '+
+


### PR DESCRIPTION
# Description
  This PR removed `'+` which was added at the end of the templates. 

_I have a question do you want me to remove the empty end-line or is it fine as it now?_

Fixes #422 

## Change In

- [x] Documentation

## Type of change

- [x] Documentation (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules